### PR TITLE
Dispatcher's own asyncmap, not Base's, on 0.5

### DIFF
--- a/src/Dispatcher.jl
+++ b/src/Dispatcher.jl
@@ -2,7 +2,11 @@ module Dispatcher
 
 # ONLY NECESSARY ON 0.5
 if VERSION < v"0.6-"
-    Base.asyncmap(f, c...; ntasks=0) = collect(Base.AsyncGenerator(f, c...; ntasks=ntasks))
+    function asyncmap(f, c...; ntasks=0)
+        collect(Base.AsyncGenerator(f, c...; ntasks=ntasks))
+    end
+else
+    asyncmap = Base.asyncmap
 end
 
 export DispatchContext,


### PR DESCRIPTION
See https://github.com/invenia/Dispatcher.jl/commit/7b4175dd6e00f5a1ee044b7bc7c832f0eabd5cbf