### PR TITLE
Allow all callables in `@op`

### DIFF
--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -138,7 +138,7 @@ This is the most common `DispatchNode`.
 """
 @auto_hash_equals type Op <: DispatchNode
     result::DeferredFuture
-    func::Function
+    func::Base.Callable
     label::String
     args
     kwargs
@@ -152,7 +152,7 @@ Any [`DispatchNode`](@ref)s which appear in the args or kwargs values will be no
 dependencies.
 The default label of an `Op` is the name of `func`.
 """
-function Op(func::Function, args...; kwargs...)
+function Op(func::Base.Callable, args...; kwargs...)
     Op(
         DeferredFuture(),
         func,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -299,6 +299,34 @@ end
                 @test collect(ctx_nodes[1].kwargs) == [(:limit, 1)]
             end
 
+            @testset "Op (using Type)" begin
+                ex = quote
+                    @dispatch_context begin
+                        @op Integer(2.0)
+                    end
+                end
+
+                expanded_ex = macroexpand(ex)
+
+                ctx = eval(expanded_ex)
+
+                @test isa(ctx, DispatchContext)
+
+                ctx_nodes = collect(nodes(ctx.graph))
+                @test length(ctx_nodes) == 1
+                @test isa(ctx_nodes[1], Op)
+                @test ctx_nodes[1].func == Integer
+                @test collect(ctx_nodes[1].args) == [2.0]
+                @test isempty(ctx_nodes[1].kwargs)
+            end
+
+            @testset "Op (using non-callable objects throws exception)" begin
+                @test_throws MethodError Op(3)
+                @test_throws MethodError Op(true)
+                @test_throws MethodError Op(print())
+                @test_throws MethodError Op([1,2])
+            end
+
             @testset "Generic (Op)" begin
                 ex = quote
                     @dispatch_context begin


### PR DESCRIPTION
Closes issue #13 