### PR TITLE
Fix `@component` not being able to reference symbols from other modules

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -76,13 +76,12 @@ macro component(func::Expr)
 
     ctx_sym = gensym("ctx")
     insert!(func.args[1].args, 2, Expr(:(::), ctx_sym, :(Dispatcher.DispatchContext)))
-    func.args[1].args[1] = esc(func.args[1].args[1])
 
     new_func = macroexpand(func)
 
     process_nodes!(new_func.args[2], ctx_sym)
 
-    return new_func
+    return esc(new_func)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ function test_addproc(x::Int; level=LOG_LEVEL)
     @everywhere Memento.config(level; fmt="[{level} | {name}]: {msg}")
 end
 
-module OtherPackage
+module OtherModule
 
 export MyType
 
@@ -399,10 +399,10 @@ end
             end
 
             @testset "Components (importing symbols from other modules)" begin
-                import OtherPackage
+                import OtherModule
 
                 ex = quote
-                    @component function foo(var::OtherPackage.MyType)
+                    @component function foo(var::OtherModule.MyType)
                         return var
                     end
 
@@ -436,7 +436,7 @@ end
             end
 
             @testset "Components (using symbols from other modules)" begin
-                using OtherPackage
+                using OtherModule
 
                 ex = quote
                     @component function foo(var::MyType)


### PR DESCRIPTION
Closes issue #14 