### PR TITLE
Fix deprecation warnings for 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.5 0.7-
 Compat 0.18.0
 IterTools 0.1.0
 LightGraphs 0.7.0
-DeferredFutures 0.3.0
+DeferredFutures 0.5.0
 DataStructures 0.5.0
 AutoHashEquals 0.0.10
 Memento 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.5 0.7-
+Compat 0.18.0
+IterTools 0.1.0
 LightGraphs 0.7.0
-Iterators 0.2.0
 DeferredFutures 0.3.0
 DataStructures 0.5.0
 AutoHashEquals 0.0.10

--- a/src/Dispatcher.jl
+++ b/src/Dispatcher.jl
@@ -40,14 +40,15 @@ export @dispatch_context,
     @include
 
 using AutoHashEquals
+using Compat
 using DataStructures
 using DeferredFutures
-using Iterators
+using IterTools
 using LightGraphs
 using Memento
 using ResultTypes
 
-abstract DispatcherError <: Exception
+@compat abstract type DispatcherError <: Exception end
 
 const logger = get_logger(current_module())
 

--- a/src/executors.jl
+++ b/src/executors.jl
@@ -1,5 +1,3 @@
-import Iterators: chain
-
 if VERSION >= v"0.6.0-dev.2830"
     import Base.Distributed: wrap_on_error, wrap_retry
 elseif VERSION >= v"0.6.0-dev.2603"
@@ -27,7 +25,7 @@ run!(exec, context)
 NOTE: Currently, it is expected that `dispatch!(::T, ::DispatchNode)` returns
 something to wait on (ie: `Task`, `Future`, `Channel`, [`DispatchNode`](@ref), etc)
 """
-abstract Executor
+@compat abstract type Executor end
 
 immutable ExecutorError{T} <: DispatcherError
     msg::T

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -1,3 +1,5 @@
+import Compat.Iterators: filter
+
 """
 `DependencyError` wraps any errors (and corresponding traceback)
 that occur on the dependency of a given nodes.
@@ -33,7 +35,7 @@ A `DispatchNode` represents a unit of computation that can be run.
 A `DispatchNode` may depend on other `DispatchNode`s, which are returned from
 the [`dependencies`](@ref) function.
 """
-abstract DispatchNode <: DeferredFutures.AbstractRemoteRef
+@compat abstract type DispatchNode <: DeferredFutures.AbstractRemoteRef end
 
 const DispatchResult = Result{DispatchNode, DependencyError}
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Iterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Dispatcher
 using ResultTypes
 using Base.Test
 using Memento
-using Iterators
+using IterTools
 
 import LightGraphs
 
@@ -925,14 +925,14 @@ end
             @testset "Referencing symbols with import" begin
                 pnums = addprocs(3)
                 @everywhere using Dispatcher
-                @everywhere import Iterators
+                @everywhere import IterTools
 
                 try
                     ctx = @dispatch_context begin
-                        a = @op Iterators.imap(+, [1,2,3], [4,5,6])
-                        b = @op Iterators.distinct(a)
-                        c = @op Iterators.nth(a, 3)
-                        c = @op Iterators.nth(b, 3)
+                        a = @op IterTools.imap(+, [1,2,3], [4,5,6])
+                        b = @op IterTools.distinct(a)
+                        c = @op IterTools.nth(a, 3)
+                        c = @op IterTools.nth(b, 3)
                     end
 
                     exec = ParallelExecutor()
@@ -949,7 +949,7 @@ end
             @testset "Referencing symbols with using" begin
                 pnums = addprocs(3)
                 @everywhere using Dispatcher
-                @everywhere using Iterators
+                @everywhere using IterTools
 
                 try
                     ctx = @dispatch_context begin


### PR DESCRIPTION
Fixed

```
WARNING: deprecated syntax "abstract DispatcherError<:Exception"
Use "abstract type DispatcherError<:Exception end" instead.
```
and 

```
WARNING: filter(flt, itr) is deprecated, use Iterators.filter(flt, itr) instead.
```
warnings.

Also updated `Iterators.jl` to `IterTools.jl` since `Iterators.jl` is deprecated.

Updated DeferredFutures version due to DeferredFuture serialization bug #21.