### PR TITLE
Change usage of `@async` to `@schedule`

### DIFF
--- a/docs/src/pages/manual.md
+++ b/docs/src/pages/manual.md
@@ -103,7 +103,7 @@ Any arguments to `DispatchNode` constructors (including in `@node` and `@op`) wh
 
 An `Executor` runs a `DispatchContext`.
 This package currently provides two `Executor`s: `AsyncExecutor` and `ParallelExecutor`.
-They work the same way, except `AsyncExecutor` runs nodes using `@async` and `ParallelExecutor` uses `@spawn`.
+They work the same way, except `AsyncExecutor` runs nodes using `@schedule` and `ParallelExecutor` uses `@spawn`.
 
 This call:
 

--- a/src/executors.jl
+++ b/src/executors.jl
@@ -430,11 +430,11 @@ end
     dispatch!(exec::AsyncExecutor, node::DispatchNode) -> Task
 
 `dispatch!` takes the `AsyncExecutor` and a `DispatchNode` to run.
-The [`run!(::DispatchNode)`](@ref) method on the node is called within an `@async` block and
-the resulting `Task` is returned.
+The [`run!(::DispatchNode)`](@ref) method on the node is called within a `@schedule` block
+and the resulting `Task` is returned.
 This is the defining method of `AsyncExecutor`.
 """
-dispatch!(exec::AsyncExecutor, node::DispatchNode) = @async run!(node)
+dispatch!(exec::AsyncExecutor, node::DispatchNode) = @schedule run!(node)
 
 """
 `ParallelExecutor` is an [`Executor`](@ref) which creates a Julia `Task` for each


### PR DESCRIPTION
According to Julia docs:
```
help?> @async
  @async

  Like @schedule, @async wraps an expression in a Task and adds it to the local machine's scheduler queue. Additionally it adds the task to the set of items that the nearest
  enclosing @sync waits for.

help?> @schedule
  @schedule

  Wrap an expression in a Task and add it to the local machine's scheduler queue. Similar to @async except that an enclosing @sync does NOT wait for tasks started with an
  @schedule.
```

We aren't using `@sync` so we shouldn't use `@async`. 