### PR TITLE
Merge dispatch method with DaskDistributedDispatcher's

### DIFF
--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -97,6 +97,7 @@ run!{T<:DispatchNode, S<:DispatchNode}(exec::Executor, nodes::AbstractArray{T}, 
 run!(::Executor, ::DispatchGraph)
 prepare!(::Executor, ::DispatchGraph)
 dispatch!(::Executor, ::DispatchGraph)
+Dispatcher.run_inner_node!(::Executor, ::DispatchNode, ::Int)
 Dispatcher.retries(::Executor)
 Dispatcher.retry_on(::Executor)
 ```


### PR DESCRIPTION
This is in relation to invenia/DaskDistributedDispatcher.jl#6 

The changes are: 
1. All the nodes are reset before any get scheduled for execution. 
2. `run_inner_node!` method was added that can be overloaded by the `DaskExecutor` to avoid overloading the entire `dispatch!(exec::Executor, graph::DispatchGraph; throw_error=true)` function.
