### PR TITLE
Register precompiled logger at runtime.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,5 @@ LightGraphs 0.7.0
 DeferredFutures 0.5.0
 DataStructures 0.5.0
 AutoHashEquals 0.1.2
-Memento 0.1.0
+Memento 0.3.2
 ResultTypes

--- a/src/Dispatcher.jl
+++ b/src/Dispatcher.jl
@@ -41,6 +41,8 @@ abstract type DispatcherError <: Exception end
 const logger = get_logger(@__MODULE__)
 const reset! = DeferredFutures.reset!  # DataStructures also exports this.
 
+__init__() = Memento.register(logger)  # Register our logger at runtime.
+
 include("nodes.jl")
 include("graph.jl")
 include("executors.jl")


### PR DESCRIPTION
This fixes a Memento issue where precompiled loggers aren't registered at runtime.