### PR TITLE
ResultTypes minimum bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,4 @@ DeferredFutures 0.5.0
 DataStructures 0.5.0
 AutoHashEquals 0.1.2
 Memento 0.5.0
-ResultTypes
+ResultTypes 1.3.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,11 @@ using ResultTypes
 using Base.Test
 using Memento
 using IterTools
-import Compat: @__MODULE__
+
 import LightGraphs
+
+using Compat: @__MODULE__
+using ResultTypes: iserror
 
 const LOG_LEVEL = "info"      # could also be "debug", "notice", "warn", etc
 


### PR DESCRIPTION
Specifically, the issue I was getting is:

```
ERROR: Unsatisfiable requirements detected for package ResultTypes:
...
├─version range [2.0.0,∞) required by package MyPkg, whose only allowed version is 0.2.0+:
│ └─version 0.2.0+ set by fixed requirement (package is checked out, dirty or pinned)
└─version range [0.1.0,2.0.0) required by package Dispatcher, whose allowed version range is [0.0.0-,∞):
...
The intersection of the requirements is empty.
```

I'm not sure why the default version range was [0.1.0,2.0.0) though :/