### PR TITLE
Allow DeferredFutures v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Dispatcher"
 uuid = "a48d5fe2-965b-541b-8ad8-ab19b69f3f25"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ ResultTypes = "08a2b407-ddc3-586a-afd6-c784ad1fffe2"
 [compat]
 AutoHashEquals = "0.1.2, 0.2"
 DataStructures = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
-DeferredFutures = "0.6"
+DeferredFutures = "0.6, 1"
 IterTools = "0.1, 0.2, 1"
 LightGraphs = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 1"
 Memento = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"


### PR DESCRIPTION
- Using v1 should help avoid this warning:
  WARNING: Compat.Distributed is deprecated, use Distributed instead.
  likely near ~/.julia/packages/DeferredFutures/6vL9r/src/DeferredFutures.jl:8